### PR TITLE
make -b support -b[float]{h,d,w,m,y} beside -b[epoch_time]

### DIFF
--- a/src/cli.c
+++ b/src/cli.c
@@ -1,22 +1,70 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
+#include <string.h>
 
 #include "lib.h"
 #include "core.h"
 
 
 void help(char *prog_name) {
-	printf("Usage: %s [-hvd] [-a count] [-r count] [-s] [-b[<since_time>]]\n",
-			prog_name);
+	printf(	"Usage: %s [-hvd] [-a count] [-r count] [-s] [-b<since_time>]\n"
+		"Options:\n"
+		"    -a count	: add the value count to budge\n"
+		"    -r count	: sub the value count from budget\n"
+		"    -s		: show statics\n"
+		"    -b[since]	: show all budget or starting from since\n"
+		"		  since is Epoch time or [float]{h,d,w,m,y}\n"
+		"    -h		: help message\n"
+		"    -v		: version\n"
+		"    -d		: output debug messages\n"
+		, prog_name);
+}
+
+struct tm *getSince(const char *since) {
+	size_t len;
+	time_t t;
+	float plus;
+	len = strlen(since);
+	// should add 1 if jsut -b{h,d,w,m,y}
+	plus = len > 1 ? 0.F : 1.F;
+	time(&t);
+	switch (since[len - 1]) {
+	case 'h':
+	case 'H':
+			t -= (time_t)((atof(since) + plus) * 3600);
+			break;
+	case 'd':
+	case 'D':
+			t -= (time_t)((atof(since) + plus) * 86400);
+			break;
+	case 'w':
+	case 'W':
+			t -= (time_t)((atof(since) + plus) * 604800);
+			break;
+	case 'm':
+	case 'M':
+			t -= (time_t)((atof(since) + plus) * 18144000);
+			break;
+	case 'y':
+	case 'Y':
+			t -= (time_t)((atof(since) + plus) * 6622560000);
+			break;
+	default:
+			t = (time_t)atoi(since);
+	}
+	return localtime(&t);
 }
 
 int main(int argc, char *argv[]) {
-	char opt;
-	unsigned int  add = 0, remove = 0, statics = 0, budget = 0,
-		      budgetSince = 0;
+	char opt, *budgetSince = NULL;
+	unsigned int  add = 0, remove = 0, statics = 0, budget = 0;
 	float addCount = 0.F, removeCount = 0.F, budgetCount = 0.F;
 	_debug = 0;
+	if (argc == 1) {
+		help(*argv);
+		exit(EXIT_SUCCESS);
+	}
 	while((opt = getopt(argc, argv, "hvdsa:r:b::")) != -1) {
 		switch(opt) {
 		case 'h':
@@ -44,14 +92,14 @@ int main(int argc, char *argv[]) {
 		case 'b':
 			budget = 1;
 			if (optarg != 0)
-				budgetSince = atoi(optarg);
+				budgetSince = optarg;
 			break;
 		default:
 			help(*argv);
 			exit(EXIT_FAILURE);
 		}
 	}
-	debug("flags: add(%d, %.3f), remove(%d, %.3f), statics(%d), budget(%d, %d)",
+	debug("flags: add(%d, %.3f), remove(%d, %.3f), statics(%d), budget(%d, %s)",
 			add, addCount, remove, removeCount, statics, budget,
 			budgetSince);
 	initCore();
@@ -63,8 +111,8 @@ int main(int argc, char *argv[]) {
 		showStatics();
 	if(budget) {
 		struct tm *since = NULL;
-		if (budgetSince > 0)
-			since = localtime((time_t *)&budgetSince);
+		if (budgetSince)
+			since = getSince(budgetSince);
 		getBudget(&budgetCount, since);
 		printf("Your Budget: %.2f\n", budgetCount);
 	}


### PR DESCRIPTION
e.g:
```shell
./moneycli -bh                                        # budget since an hour
./moneycli -b2M                                       # budget since 2 months
./moneycli -b3.5d                                     # budget since 3 days and half
./moneycli -b$(date -d "2015-01-04 10:04:50" +%s)     # budget since 2015-01-04 10:04:50 the Epoch time way
```